### PR TITLE
Fix #17964

### DIFF
--- a/js/src/util.js
+++ b/js/src/util.js
@@ -116,7 +116,7 @@ const Util = (($) => {
     },
 
     reflow(element) {
-      new Function('bs', 'return bs')(element.offsetHeight)
+      return element.offsetHeight
     },
 
     triggerTransitionEnd(element) {

--- a/js/src/util.js
+++ b/js/src/util.js
@@ -116,7 +116,7 @@ const Util = (($) => {
     },
 
     reflow(element) {
-      return element.offsetHeight;
+      return element.offsetHeight
     },
 
     triggerTransitionEnd(element) {

--- a/js/src/util.js
+++ b/js/src/util.js
@@ -116,7 +116,7 @@ const Util = (($) => {
     },
 
     reflow(element) {
-      return element.offsetHeight
+      return element.offsetHeight;
     },
 
     triggerTransitionEnd(element) {


### PR DESCRIPTION
Some browsers are lazy when updating dom elements after transition effects. This can be fixed by reading element properties such as offsetHeight or offsetWidth, which causes the browser to resync (reflow) the elements.

However, creating a function using the Function constructor just to access such element, results in a violation of Content Security Policy (where applied), which in turn crashes the application. This fix actually reverts to the way this was handled in v3 and should work as intended.